### PR TITLE
Set capabilities on binary, do not report changes on version check

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,6 @@ restic_group: 'root'
 
 # restic set suid access
 restic_mode: '0755'
+
+# restic binary capabilities
+restic_capability: 'cap_dac_read_search+ep'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,3 +35,11 @@
     mode: "{{restic_mode}}"
   when:
     - not ansible_unit_test
+
+- name: set capabilities for restic binary
+  capabilities:
+    path: "{{restic_install_directory}}/{{restic_name}}"
+    capability: "{{ restic_capability }}"
+    state: present
+  when:
+    - not ansible_unit_test

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,5 +30,5 @@
     desired_version_installed: "{{ restic_version_info.stdout_lines[0].find(restic_version) != -1}}"
   when: restic_executable.stat.exists
 
-- include: "install.yml"
+- include_tasks: "install.yml"
   when: not restic_executable.stat.exists or not desired_version_installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: get restic version info
   shell: "{{restic_install_directory}}/{{restic_name}} version"
   register: restic_version_info
+  changed_when: false
   when: restic_executable.stat.exists
 
 - name: get latest version info


### PR DESCRIPTION
Hi, thanks for creating this role. I've added capabilities setup so users can follow [this root-less approach](https://restic.readthedocs.io/en/latest/080_examples.html?highlight=capabilities#capabilities-on-linux).

I've also added `changed_when: false` on the version check so it doesn't report change when there is none.